### PR TITLE
**Update**

### DIFF
--- a/ExceptionLib/src/main/java/org/csystem/util/exception/ExceptionUtil.java
+++ b/ExceptionLib/src/main/java/org/csystem/util/exception/ExceptionUtil.java
@@ -1,13 +1,4 @@
-/*----------------------------------------------------------------------
-FILE        : ExceptionUtil.java
-AUTHOR      : Oğuz Karan
-LAST UPDATE : 19.09.2021
 
-ExceptionUtil class for exception managing
-
-Copyleft (c) 1993 by C and System Programmers Association (CSD)
-All Rights Free
------------------------------------------------------------------------*/
 package org.csystem.util.exception;
 
 import java.io.Closeable;
@@ -15,21 +6,48 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+/**
+ * Utility class for exception handling operations, including throwing specified types of runtime exceptions
+ * and executing actions or suppliers with exception handling and resource management.
+ * <p>1993 by C and System Programmers Association (CSD) All Rights Free</p>
+ * @author JavaApp2-Jan-2024 Group
+ * @version 1.0.0
+ */
 public final class ExceptionUtil {
+
+    /**
+     * Throws specified type of RuntimeException with the provided message and the original exception as the cause.
+     * @param <T> the type of the exception that extends {@link RuntimeException}
+     * @param msg the message to include in the RuntimeException
+     * @param cls the class of the RuntimeException to be thrown
+     * @param ex  the cause of the exception
+     * @throws UnsupportedOperationException if the specified RuntimeException class doesn't have a constructor that accepts a String and a Throwable
+     */
     private static <T extends RuntimeException> void throwException(String msg, Class<T> cls, Throwable ex)
     {
         try {
             throw cls.getConstructor(String.class, Throwable.class).newInstance(msg, ex);
         }
-        catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException | InstantiationException e) {
+        catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException |
+               InstantiationException e) {
             throw new UnsupportedOperationException("Fault for exception class");
         }
     }
 
     private ExceptionUtil()
-    {}
+    {
+    }
 
-    public static <T extends RuntimeException> void doWorkForRunnable(IActionCallback actionCallback, String msg, Class<T> cls)
+
+    /**
+     * Executes the given action and handles any thrown exceptions by wrapping and rethrowing them as specified exceptions.
+     * If an exception is thrown, a new RuntimeException is thrown with the provided message and the original exception as the cause.
+     * @param actionCallback the {@link IAction} action to be executed
+     * @param msg the detail message for the exception if one is thrown
+     * @param cls the class of the exception to be thrown if an exception occurs during the action execution
+     * @throws T if an exception occurs during the action execution, and it's rethrown as the specified type
+     */
+    public static <T extends RuntimeException> void doWorkForRunnable(IAction actionCallback, String msg, Class<T> cls)
     {
         try {
             actionCallback.run();
@@ -39,7 +57,19 @@ public final class ExceptionUtil {
         }
     }
 
-    public static <T extends RuntimeException> void doWorkForRunnable(IActionCallback actionCallback, Consumer<Throwable> consumer, String msg, Class<T> cls)
+
+    /**
+     * Executes the given action and handles any thrown exceptions by wrapping and rethrowing them as specified exceptions.
+     * If an exception is thrown, it is passed to the provided consumer and then a new RuntimeException is thrown with the
+     * provided message and the original exception as the cause.
+     * @param <T> the type of the exception that extends {@link RuntimeException}
+     * @param actionCallback the action to be executed
+     * @param consumer the {@link Consumer} that processes the exception before it is wrapped and rethrown.
+     * @param msg the detail message for the exception if one is thrown
+     * @param cls the class of the exception to be thrown if an exception occurs during the action execution
+     * @throws T if an exception occurs during the action execution, and it's rethrown as the specified type
+     */
+    public static <T extends RuntimeException> void doWorkForRunnable(IAction actionCallback, Consumer<Throwable> consumer, String msg, Class<T> cls)
     {
         try {
             actionCallback.run();
@@ -50,7 +80,18 @@ public final class ExceptionUtil {
         }
     }
 
-    public static <T extends RuntimeException, R> R doWorkFor(ISupplierCallback<R> supplier, String msg, Class<T> cls)
+
+    /**
+     * Executes a given supplier function and handles any exceptions thrown during execution.
+     * @param <T>      the type of the runtime exception to be thrown in case of failure. It must extend {@link RuntimeException}.
+     * @param <R>      the type of result returned by the {@code supplier}.
+     * @param supplier the {@link ISupplier} function to be executed. It must have a method {@code get()} that returns a result of type {@code R}.
+     * @param msg      the message to be included in the exception thrown if an error occurs.
+     * @param cls      the class of the RuntimeException to be thrown
+     * @return R the result produced by the {@code supplier}.
+     * @throws T if an exception occurs during the action execution, and it's rethrown as the specified type
+     */
+    public static <T extends RuntimeException, R> R doWorkFor(ISupplier<R> supplier, String msg, Class<T> cls)
     {
         R result = null;
 
@@ -64,7 +105,18 @@ public final class ExceptionUtil {
         return result;
     }
 
-    public static <T extends RuntimeException, R> R doWorkFor(ISupplierCallback<R> supplier, Consumer<Throwable>  consumer, String msg, Class<T> cls)
+    /**
+     * Executes a given supplier function and handles any exceptions thrown during execution.
+     * @param <T>      the type of the runtime exception to be thrown in case of failure. It must extend {@link RuntimeException}.
+     * @param <R>      the type of result returned by the {@code supplier}.
+     * @param supplier the {@link ISupplier} function to be executed. It must have a method {@code get()} that returns a result of type {@code R}.
+     * @param msg      the message to be included in the exception thrown if an error occurs.
+     * @param cls      the class of the RuntimeException to be thrown
+     * @param consumer the {@link Consumer} that processes the exception before it is wrapped and rethrown.
+     * @return R the result produced by the {@code supplier}.
+     * @throws T if an exception occurs during the action execution, and it's rethrown as the specified type
+     */
+    public static <T extends RuntimeException, R> R doWorkFor(ISupplier<R> supplier, Consumer<Throwable> consumer, String msg, Class<T> cls)
     {
         R result = null;
 
@@ -79,7 +131,16 @@ public final class ExceptionUtil {
         return result;
     }
 
-    public static <R> R doWorkForRuntimeException(ISupplierCallback<R> supplier, String msg)
+
+    /**
+     * Executes a given supplier function and wraps any exceptions thrown during execution in a {@link RuntimeException}.
+     * @param <R>      the type of result returned by the {@code supplier}.
+     * @param supplier the {@link ISupplier} function to be executed. It must have a method {@code get()} that returns a result of type {@code R}.
+     * @param msg      the message to be included in the {@link RuntimeException} if an error occurs.
+     * @return R the result produced by the {@code supplier}.
+     * @throws RuntimeException if an exception occurs during the action execution, it'll be caught and wrapped in a {@link RuntimeException} with the provided message and the original exception as the cause.
+     */
+    public static <R> R doWorkForRuntimeException(ISupplier<R> supplier, String msg)
     {
         try {
             return supplier.get();
@@ -89,7 +150,13 @@ public final class ExceptionUtil {
         }
     }
 
-    public static void doWorkForRuntimeException(IActionCallback actionCallback, String msg)
+    /**
+     * Executes a given action and wraps any exceptions thrown during execution in a {@link RuntimeException}.
+     * @param actionCallback the {@link IAction} action to be executed
+     * @param msg the message to be included in the {@link RuntimeException} if an error occurs.
+     * @throws RuntimeException if an exception occurs during the action execution, it'll be caught and wrapped in a {@link RuntimeException} with the provided message and the original exception as the cause.
+     */
+    public static void doWorkForRuntimeException(IAction actionCallback, String msg)
     {
         try {
             actionCallback.run();
@@ -99,7 +166,14 @@ public final class ExceptionUtil {
         }
     }
 
-    public static <R> R subscribe(ISupplierCallback<R> supplier, Function<Throwable, R> function)
+    /**
+     * Executes a given supplier function and applies a provided function to handle any exceptions thrown during execution.
+     * @param <R>      the type of result returned by both the {@code supplier} and the {@code function}.
+     * @param supplier the {@link ISupplier} function to be executed. It must have a method {@code get()} that returns a result of type {@code R}.
+     * @param function the {@link Function} that processes the exception if one is thrown. It takes a {@link Throwable} as input and returns a result of type {@code R}.
+     * @return the result produced by the {@code supplier} if no exception occurs, or the result produced by the {@code function} if an exception is thrown.
+     */
+    public static <R> R subscribe(ISupplier<R> supplier, Function<Throwable, R> function)
     {
         try {
             return supplier.get();
@@ -109,7 +183,12 @@ public final class ExceptionUtil {
         }
     }
 
-    public static void subscribeRunnable(IActionCallback actionCallback, Consumer<Throwable> consumer)
+    /**
+     * Executes a given action and processes any exceptions thrown during execution with a provided consumer.
+     * @param actionCallback the {@link IAction} callback to be executed. Provide the {@code run()} method to execute the action.
+     * @param consumer       the {@link Consumer} that processes the exception before it is wrapped and rethrown.
+     */
+    public static void subscribeRunnable(IAction actionCallback, Consumer<Throwable> consumer)
     {
         try {
             actionCallback.run();
@@ -119,7 +198,19 @@ public final class ExceptionUtil {
         }
     }
 
-    public static <R> R subscribe(ISupplierCallback<R> supplier, Function<Throwable, R> function, Runnable runnableCompleted)
+
+    /**
+     * Executes a given supplier function, handles any exceptions thrown during execution with a provided function,
+     * and always runs a specified runnable upon completion.
+     * @param <R> the type of result returned by both the {@code supplier} and the {@code function}.
+     * @param supplier the {@link ISupplier} function to be executed. It must have a method {@code get()} that returns a result of type {@code R}.
+     * @param function the {@link Function} that processes the exception if one is thrown. It takes a {@link Throwable}
+     * as input and returns a result of type {@code R}.
+     * @param runnableCompleted the {@link Runnable} that is always executed after the {@code supplier} function
+     * completes, regardless of whether an exception occurred or not.
+     * @return the result produced by the {@code supplier} if no exception occurs, or the result produced by the {@code function} if an exception is thrown.
+     */
+    public static <R> R subscribe(ISupplier<R> supplier, Function<Throwable, R> function, Runnable runnableCompleted)
     {
         try {
             return supplier.get();
@@ -132,7 +223,14 @@ public final class ExceptionUtil {
         }
     }
 
-    public static void subscribeRunnable(IActionCallback actionCallback, Consumer<Throwable> consumer, Runnable runnableCompleted)
+    /**
+     * Executes a given action and processes any exceptions thrown during execution with a provided consumer,
+     * while always executing a specified runnable upon completion.
+     * @param actionCallback the {@link IAction} callback to be executed. Provide the {@code run()} method to execute the action.
+     * @param consumer the {@link Consumer} that processes any {@link Throwable} that occurs during execution. It accepts the exception and allows for custom handling.
+     * @param runnableCompleted the {@link Runnable} that is always executed after the {@code actionCallback} completes, regardless of whether an exception occurred or not.
+     */
+    public static void subscribeRunnable(IAction actionCallback, Consumer<Throwable> consumer, Runnable runnableCompleted)
     {
         try {
             actionCallback.run();
@@ -145,7 +243,17 @@ public final class ExceptionUtil {
         }
     }
 
-    public static <R> R subscribe(ISupplierCallback<R> supplier, Closeable closeable, Function<Throwable, R> function, Runnable runnableCompleted)
+    /**
+     * Executes a supplier function, handles any exceptions thrown during execution with a provided function,
+     * and ensures a closeable resource is managed properly, while always running a specified runnable upon completion.
+     * @param <R> the type of result returned by both the {@code supplier} and the {@code function}.
+     * @param supplier the {@link ISupplier} function to be executed. It must have a method {@code get()} that returns a result of type {@code R}.
+     * @param closeable the {@link Closeable} resource that will be automatically closed after the {@code supplier} function completes, whether an exception occurs or not.
+     * @param function the {@link Function} that processes the exception if one is thrown. It takes a {@link Throwable} as input and returns a result of type {@code R}.
+     * @param runnableCompleted the {@link Runnable} that is always executed after the {@code supplier} function completes, regardless of whether an exception occurred or not.
+     * @return the result produced by the {@code supplier} if no exception occurs, or the result produced by the {@code function} if an exception is thrown.
+     */
+    public static <R> R subscribe(ISupplier<R> supplier, Closeable closeable, Function<Throwable, R> function, Runnable runnableCompleted)
     {
         try (closeable) {
             return supplier.get();
@@ -158,7 +266,15 @@ public final class ExceptionUtil {
         }
     }
 
-    public static void subscribeRunnable(IActionCallback actionCallback, Closeable closeable, Consumer<Throwable> consumer, Runnable runnableCompleted)
+    /**
+     * Executes a given action, handles any exceptions thrown during execution with a provided consumer,
+     * ensures a closeable resource is managed properly, and always runs a specified runnable upon completion.
+     * @param actionCallback the {@link IAction} callback to be executed. Provide the {@code run()} method to execute the action.
+     * @param closeable the {@link Closeable} resource that will be automatically closed after the {@code actionCallback} completes, whether an exception occurs or not.
+     * @param consumer the {@link Consumer} that processes any {@link Throwable} that occurs during execution. It accepts the exception and allows for custom handling.
+     * @param runnableCompleted the {@link Runnable} that is always executed after the {@code actionCallback} completes, regardless of whether an exception occurred or not.
+     */
+    public static void subscribeRunnable(IAction actionCallback, Closeable closeable, Consumer<Throwable> consumer, Runnable runnableCompleted)
     {
         try (closeable) {
             actionCallback.run();
@@ -171,7 +287,16 @@ public final class ExceptionUtil {
         }
     }
 
-    public static <R> R subscribe(ISupplierCallback<R> supplier, Closeable closeable, Function<Throwable, R> function)
+    /**
+     * Executes a supplier function, handles any exceptions thrown during execution with a provided function,
+     * and ensures a closeable resource is managed properly.
+     * @param <R> the type of result returned by both the {@code supplier} and the {@code function}.
+     * @param supplier the {@link ISupplier} function to be executed. It must have a method {@code get()} that returns a result of type {@code R}.
+     * @param closeable the {@link Closeable} resource that'll be automatically closed after the {@code supplier} function completes, whether an exception occurs or not.
+     * @param function  the {@link Function} that processes the exception if one is thrown. It takes a {@link Throwable} as input and returns a result of type {@code R}.
+     * @return the result produced by the {@code supplier} if no exception occurs, or the result produced by the {@code function} if an exception is thrown.
+     */
+    public static <R> R subscribe(ISupplier<R> supplier, Closeable closeable, Function<Throwable, R> function)
     {
         try (closeable) {
             return supplier.get();
@@ -181,7 +306,14 @@ public final class ExceptionUtil {
         }
     }
 
-    public static void subscribeRunnable(IActionCallback actionCallback, Closeable closeable, Consumer<Throwable> consumer)
+    /**
+     * Executes a given action, handles any exceptions thrown during execution with a provided consumer,
+     * and ensures a closeable resource is managed properly.
+     * @param actionCallback the {@link IAction} callback to be executed. Provide the {@code run()} method to execute the action.
+     * @param closeable the {@link Closeable} resource that'll be automatically closed after the {@code actionCallback} completes, whether an exception occurs or not.
+     * @param consumer       the {@link Consumer} that processes any {@link Throwable} that occurs during execution. It accepts the exception and allows for custom handling.
+     */
+    public static void subscribeRunnable(IAction actionCallback, Closeable closeable, Consumer<Throwable> consumer)
     {
         try (closeable) {
             actionCallback.run();

--- a/ExceptionLib/src/main/java/org/csystem/util/exception/IAction.java
+++ b/ExceptionLib/src/main/java/org/csystem/util/exception/IAction.java
@@ -1,9 +1,9 @@
 /*----------------------------------------------------------------------
-FILE        : ISupplierCallback.java
+FILE        : IAction.java
 AUTHOR      : Oğuz Karan
 LAST UPDATE : 30.09.2020
 
-ISupplierCallback<T> functional interface
+IAction functional interface
 
 Copyleft (c) 1993 by C and System Programmers Association (CSD)
 All Rights Free
@@ -11,6 +11,6 @@ All Rights Free
 package org.csystem.util.exception;
 
 @FunctionalInterface
-public interface ISupplierCallback<R> {
-    R get() throws Exception;
+public interface IAction {
+    void run() throws Exception;
 }

--- a/ExceptionLib/src/main/java/org/csystem/util/exception/ISupplier.java
+++ b/ExceptionLib/src/main/java/org/csystem/util/exception/ISupplier.java
@@ -1,9 +1,9 @@
 /*----------------------------------------------------------------------
-FILE        : IActionCallback.java
+FILE        : ISupplier.java
 AUTHOR      : Oğuz Karan
 LAST UPDATE : 30.09.2020
 
-IActionCallback functional interface
+ISupplier<T> functional interface
 
 Copyleft (c) 1993 by C and System Programmers Association (CSD)
 All Rights Free
@@ -11,6 +11,6 @@ All Rights Free
 package org.csystem.util.exception;
 
 @FunctionalInterface
-public interface IActionCallback {
-    void run() throws Exception;
+public interface ISupplier<R> {
+    R get() throws Exception;
 }


### PR DESCRIPTION
- Instead of changing name of the old branch ``JavaDoc-ExceptionLib-İbrahim-Deniz``, we decided to create new branch with proper naming convention from dev branch

- Because of dev branch is behind of the main branch, also change the names of the ``IActionCallBack`` to ``IAction`` and  ``ISupplierCallBack`` to ``ISupplier``