### PR TITLE
Fix: NetLib failing test

### DIFF
--- a/NetLib/pom.xml
+++ b/NetLib/pom.xml
@@ -39,6 +39,17 @@
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>3.3.0</version>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+                <configuration>
+                    <forkCount>1</forkCount>
+                    <reuseForks>false</reuseForks>
+                    <parallel>none</parallel>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/NetLib/src/test/java/com/karandev/util/net/tcp/util/TcpUtilGetFirstAvailableSocketTest.java
+++ b/NetLib/src/test/java/com/karandev/util/net/tcp/util/TcpUtilGetFirstAvailableSocketTest.java
@@ -15,7 +15,7 @@ import static com.karandev.util.net.TcpUtil.*;
 public class TcpUtilGetFirstAvailableSocketTest {
     private static final int MIN_PORT = 1024;
     private static final int MAX_PORT = 8192;
-    private static final int[] ALLOWED_PORT_RANGE = IntStream.rangeClosed(1024, 65533).toArray();
+    private static final int[] ALLOWED_PORT_RANGE = IntStream.rangeClosed(2048, 4096).toArray();
 
     @Test
     public void givenPortNumberRange_whenAvailable_thenPortAssigned() throws InterruptedException


### PR DESCRIPTION
- Disable surefire parallel test runs
- Decrease the tested port range in `whenAllPortsAreBusy_thenReturnEmptyOptional` test method